### PR TITLE
DISCO-516 pass id prop to iframe element

### DIFF
--- a/src/iframe.js
+++ b/src/iframe.js
@@ -30,10 +30,11 @@ export default class Iframe extends React.Component {
   }
 
   render() {
-    const { src, width, height, className, scrollStatus } = this.props;
+    const { src, width, height, className, scrollStatus, id } = this.props;
     return (
       <iframe
         src={src}
+        id={id}
         width={width}
         height={height}
         className={classNames('widget-iframe', className)}
@@ -56,5 +57,6 @@ if (process.env.NODE_ENV !== 'production') {
     height: PropTypes.string,
     className: PropTypes.string,
     scrollStatus: PropTypes.string,
+    id: PropTypes.string,
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,10 @@ describe('Widget', () => {
       widget.should.have.tagName('iframe');
       widget.should.have.className('widget-iframe');
     });
+    it('should contain id only when defined by props', () => {
+      mount(<Widget iframe={{ id: 'primary' }} />).find('.widget-iframe').should.have.prop('id', 'primary');
+      widget.should.not.have.property('id');
+    });
   });
 
 });


### PR DESCRIPTION
As DISCO-516 deals with replication of iframe, we need to have an id parameter to make it possible to switch between multiple iframes and also to scrollIntoView to reach the current one.